### PR TITLE
allow to specify the view class as generic on Mediator

### DIFF
--- a/definitions/pixi.d.ts
+++ b/definitions/pixi.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="../lib/index.d.ts" />
+/// <reference types="robotlegs" />
 
 import { IEvent } from "robotlegs";
 
@@ -11,8 +11,8 @@ declare module "pixi.js" {
         addEventListener(type: string, listener?: Function): void;
         hasEventListener(type: string, listener?: Function): boolean;
         removeEventListener(type: string, listener?: Function): void;
-        willTrigger(type: string): void;
-        dispatchEvent(event: IEvent): void;
+        willTrigger(type: string): boolean;
+        dispatchEvent(event: IEvent): boolean;
     }
 
     export interface DisplayObject extends IEventDispatcher {}

--- a/example/view/CircleMediator.ts
+++ b/example/view/CircleMediator.ts
@@ -2,10 +2,7 @@ import { inject } from "robotlegs";
 import { CircleView } from "./CircleView"
 import { Mediator } from "../../src/index";
 
-export class CircleMediator extends Mediator {
-
-    @inject(CircleView)
-    view: CircleView;
+export class CircleMediator extends Mediator<CircleView> {
 
     initialize()
     {

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/Mediator.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/Mediator.ts
@@ -21,7 +21,7 @@ import { IMediator } from "../api/IMediator";
  * <p>Override initialize and destroy to hook into the mediator lifecycle.</p>
  */
 @injectable()
-export abstract class Mediator implements IMediator {
+export abstract class Mediator<T extends IEventDispatcher> implements IMediator {
 
     /*============================================================================*/
     /* Protected Properties                                                       */
@@ -33,17 +33,18 @@ export abstract class Mediator implements IMediator {
     @inject(IEventDispatcher)
     protected eventDispatcher: IEventDispatcher;
 
-    protected _viewComponent: IEventDispatcher;
+    protected _viewComponent: T;
 
     /*============================================================================*/
     /* Public Properties                                                          */
     /*============================================================================*/
 
-    /**
-     * @private
-     */
-    public set viewComponent(view: IEventDispatcher) {
+    public set view(view: T) {
         this._viewComponent = view;
+    }
+
+    public get view(): T {
+        return this._viewComponent;
     }
 
     /*============================================================================*/

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorManager.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorManager.ts
@@ -81,8 +81,8 @@ export class MediatorManager {
         if ('preInitialize' in mediator)
             mediator.preInitialize();
 
-        if ('viewComponent' in mediator)
-            mediator.viewComponent = mediatedItem;
+        if ('view' in mediator)
+            mediator.view = mediatedItem;
 
         if ('initialize' in mediator)
             mediator.initialize();
@@ -98,8 +98,8 @@ export class MediatorManager {
         if ('destroy' in mediator)
             mediator.destroy();
 
-        if ('viewComponent' in mediator)
-            mediator.viewComponent = null;
+        if ('view' in mediator)
+            mediator.view = null;
 
         if ('postDestroy' in mediator)
             mediator.postDestroy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "./test/**/*.ts"
   ],
   "files": [
-    "./typings/index.d.ts"
+    "./typings/index.d.ts",
+    "./definitions/pixi.d.ts"
   ]
 }


### PR DESCRIPTION
As requested in #4, this pull request allows you to specify the view class used by the mediator. 
- It is being assumed that the view class implements the `IEventDispatcher` interface, to play nice with [EventMap](https://github.com/GoodgameStudios/RobotlegsJS/blob/master/src/robotlegs/bender/extensions/localEventMap/impl/EventMap.ts). (`robotlegs-pixi` is currently [patching](https://github.com/GoodgameStudios/RobotlegsJS-Pixi/blob/master/src/robotlegs/bender/extensions/contextView/pixiPatch/eventemitter3-patch.ts) PIXI to force the implementation in their end.)
- Rename the `_viewComponent` property as just `view`, to have a shorter reference when implementing the mediator.

Thoughts @tiagoschenkel @cuongdd2?
