### PR TITLE
fix missing `index` param of Container.addChildAt

### DIFF
--- a/src/robotlegs/bender/extensions/contextView/pixiPatch/index.ts
+++ b/src/robotlegs/bender/extensions/contextView/pixiPatch/index.ts
@@ -21,7 +21,7 @@ export function applyPixiPatch(interaction: any) {
     }
 
     PIXI.Container.prototype.addChildAt = function(child, index): PIXI.DisplayObject {
-        addChildAt.call(this, child);
+        addChildAt.call(this, child, index);
         interaction.emit("added", { target: child })
         return this;
     }


### PR DESCRIPTION
fix missing `index` param of Container.addChildAt that causes child will always be added at 0 index