### PR TITLE
fixes bug of `pixiPatch` releates to `removeChild`

### DIFF
--- a/src/robotlegs/bender/extensions/contextView/pixiPatch/index.ts
+++ b/src/robotlegs/bender/extensions/contextView/pixiPatch/index.ts
@@ -29,14 +29,14 @@ export function applyPixiPatch(interaction: any) {
     PIXI.Container.prototype.removeChild = function(...child): PIXI.DisplayObject {
         for (var i = 0, len = child.length; i < len; i++) {
             removeChild.call(this, child[i]);
-            interaction.emit("removed", { target: child })
+            interaction.emit("removed", { target: child[i] })
         }
         return this;
     }
 
     PIXI.Container.prototype.removeChildAt = function(index): PIXI.DisplayObject {
-        removeChildAt.call(this, index);
-        interaction.emit("removed", { target: this.getChildAt(index) });
+        var child = removeChildAt.call(this, index);
+        interaction.emit("removed", { target: child });
         return this;
     }
 

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorFactory.ts
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorFactory.ts
@@ -84,9 +84,7 @@ export class MediatorFactory {
         if (!mediators)
             return;
 
-        for (var mapping in mediators) {
-            this._manager.removeMediator(mediators[mapping], item, <any>mapping);
-        }
+        mediators.forEach((value, key) => this._manager.removeMediator(value, item, key));
 
         this._mediators.delete(item);
     }


### PR DESCRIPTION
`Mediator.destroy()` method is not called properly cause of this bug